### PR TITLE
bench: fix unbalanced parens in 5 micro-bench files

### DIFF
--- a/racket/prologos/benchmarks/micro/bench-ppn-track2.rkt
+++ b/racket/prologos/benchmarks/micro/bench-ppn-track2.rkt
@@ -409,7 +409,7 @@
     ;; Time full process-file
     (define-values (_1 total-ms)
       (time-ms (lambda ()
-          (process-file f)))))
+          (process-file f))))
     (printf "  ~a: total=~a ms\n"
             fname
             (~r total-ms #:precision '(= 1)))))
@@ -438,7 +438,7 @@
   (with-handlers ([exn? (lambda (e) (void))])
     (define-values (_1 total-ms)
       (time-ms (lambda ()
-          (process-file f)))))
+          (process-file f))))
     (set! lib-timings (cons (list fname total-ms) lib-timings))))
 
 ;; Sort by time, show top 10

--- a/racket/prologos/benchmarks/micro/bench-ppn-track3.rkt
+++ b/racket/prologos/benchmarks/micro/bench-ppn-track3.rkt
@@ -83,7 +83,7 @@
 
 (define (process-ws-silent src)
   (silent (lambda ()
-      (process-string-ws src)))))
+      (process-string-ws src))))
 
 ;; ========================================
 ;; Test programs
@@ -291,7 +291,7 @@
 
 (bench "full-pipeline sexp (simple)"
        (lambda () (silent (lambda ()
-           (process-string sexp-simple)))))
+           (process-string sexp-simple))))
        #:runs 10 #:warmup 3)
 
 (bench "full-pipeline WS (data-match)"
@@ -591,7 +591,7 @@
                                              (min 80 (string-length (exn-message e))))))])
     (define-values (_1 total-ms)
       (time-ms (lambda ()
-          (process-file f)))))
+          (process-file f))))
     (printf "  ~a: ~a ms\n" fname (~r total-ms #:precision '(= 1)))))
 
 
@@ -627,7 +627,7 @@
                                              (min 60 (string-length (exn-message e))))))])
     (define-values (_1 total-ms)
       (time-ms (lambda ()
-          (process-file f)))))
+          (process-file f))))
     (printf "  ~a (~a bytes): ~a ms\n" fname size (~r total-ms #:precision '(= 1)))))
 
 
@@ -663,7 +663,7 @@
                                              (min 80 (string-length (exn-message e)))))
                           (set! e3-fail (+ e3-fail 1)))])
       (process-file f))
-    (set! e3-pass (+ e3-pass 1))))
+    (set! e3-pass (+ e3-pass 1)))
 
 (printf "\n  Result: ~a pass, ~a fail out of ~a\n" e3-pass e3-fail (length example-files))
 
@@ -682,7 +682,7 @@
 
 (bench "E4 sexp: simple"
        (lambda () (silent (lambda ()
-           (process-string sexp-simple)))))
+           (process-string sexp-simple))))
        #:runs 10 #:warmup 3)
 
 (bench "E4 WS: medium (20 defs)"
@@ -691,7 +691,7 @@
 
 (bench "E4 sexp: medium (20 defs)"
        (lambda () (silent (lambda ()
-           (process-string sexp-medium)))))
+           (process-string sexp-medium))))
        #:runs 5 #:warmup 2)
 
 

--- a/racket/prologos/benchmarks/micro/bench-ppn-track4.rkt
+++ b/racket/prologos/benchmarks/micro/bench-ppn-track4.rkt
@@ -318,27 +318,27 @@
 
 (define e1 (bench-ms "E1 simple (def+spec+eval, no metas)" 10
   (silent (lambda ()
-      (process-string-ws e1-src))))))
+      (process-string-ws e1-src)))))
 
 (define e2 (bench-ms "E2 pattern matching (data+defn arms)" 10
   (silent (lambda ()
-      (process-string-ws e2-src))))))
+      (process-string-ws e2-src)))))
 
 (define e3 (bench-ms "E3 mixed-type maps (union speculation)" 10
   (silent (lambda ()
-      (process-string-ws e3-src))))))
+      (process-string-ws e3-src)))))
 
 (define e4 (bench-ms "E4 list + map (polymorphic, prelude)" 10
   (silent (lambda ()
-      (process-string-ws e4-src))))))
+      (process-string-ws e4-src)))))
 
 (define e5 (bench-ms "E5 generic arithmetic (trait dispatch)" 10
   (silent (lambda ()
-      (process-string-ws e5-src))))))
+      (process-string-ws e5-src)))))
 
 (define e6 (bench-ms "E6 recursive function (fib)" 10
   (silent (lambda ()
-      (process-string-ws e6-src))))))
+      (process-string-ws e6-src)))))
 
 
 ;; ============================================================

--- a/racket/prologos/benchmarks/micro/bench-sre-track2d.rkt
+++ b/racket/prologos/benchmarks/micro/bench-sre-track2d.rkt
@@ -314,19 +314,19 @@
 
 (define e1 (bench-ms "E1 if/let rewrites" 10
   (silent (lambda ()
-      (process-string-ws e1-src))))))
+      (process-string-ws e1-src)))))
 
 (define e2 (bench-ms "E2 dot-access + implicit-map" 10
   (silent (lambda ()
-      (process-string-ws e2-src))))))
+      (process-string-ws e2-src)))))
 
 (define e3 (bench-ms "E3 pattern matching (full pipeline)" 10
   (silent (lambda ()
-      (process-string-ws e3-src))))))
+      (process-string-ws e3-src)))))
 
 (define e4 (bench-ms "E4 list literals (fold rewrite)" 10
   (silent (lambda ()
-      (process-string-ws e4-src))))))
+      (process-string-ws e4-src)))))
 
 
 ;; ============================================================

--- a/racket/prologos/benchmarks/micro/bench-sre-track2h.rkt
+++ b/racket/prologos/benchmarks/micro/bench-sre-track2h.rkt
@@ -326,7 +326,7 @@
 
 (define e1 (bench-ms "E1 numeric subtyping (simple)" 10
   (silent (lambda ()
-      (process-string-ws e1-src))))))
+      (process-string-ws e1-src)))))
 
 ;; E2: Mixed-type map (existing union type consumer)
 (define e2-src
@@ -338,7 +338,7 @@
 
 (define e2 (bench-ms "E2 mixed-type map (union values)" 10
   (silent (lambda ()
-      (process-string-ws e2-src))))))
+      (process-string-ws e2-src)))))
 
 ;; E3: Pattern matching (exercises type checking with multiple branches)
 (define e3-src
@@ -354,7 +354,7 @@
 
 (define e3 (bench-ms "E3 pattern matching (multiple branches)" 10
   (silent (lambda ()
-      (process-string-ws e3-src))))))
+      (process-string-ws e3-src)))))
 
 ;; E4: Trait with subtype (exercises subtype? in resolution)
 (define e4-src
@@ -367,7 +367,7 @@
 
 (define e4 (bench-ms "E4 subtype in arithmetic context" 10
   (silent (lambda ()
-      (process-string-ws e4-src))))))
+      (process-string-ws e4-src)))))
 
 
 ;; ============================================================


### PR DESCRIPTION
## Summary

Each affected line had one extra trailing `)` from a paste-error pattern introduced in `d7bd97a` ("PPN 4C S2.e-iv-c: retire 6 store/champ-box parameters + 169-test-file fixture surgery").

`raco pkg install --auto --skip-installed` runs `raco setup`, which compiles the whole package — including `benchmarks/micro/`. With these files broken, `install` exits non-zero, breaking CI on `main` and on every open PR (including #28, where the failure first surfaced).

## Changes

22 lines changed (one extra `)` removed on each):

- `bench-ppn-track2.rkt:412, 441`
- `bench-ppn-track3.rkt:86, 294, 594, 630, 666, 685, 694`
- `bench-ppn-track4.rkt:321, 325, 329, 333, 337, 341`
- `bench-sre-track2d.rkt:317, 321, 325, 329`
- `bench-sre-track2h.rkt:329, 341, 357, 370`

No semantic change.

## Test plan

- [x] Each touched file: `raco make benchmarks/micro/<file>.rkt` → exit 0
- [x] Full bench dir: `for f in benchmarks/micro/*.rkt; do raco make "$f"; done` → all clean
- [ ] CI: `Tests` workflow's `Install dependencies` step succeeds (this is the step the bug was blocking)
- [ ] CI: full test suite still passes (no semantic change, expected)

https://claude.ai/code/session_01YM6gc3cMNH2Ymor4jdZY8u

---
_Generated by [Claude Code](https://claude.ai/code/session_01YM6gc3cMNH2Ymor4jdZY8u)_