### PR TITLE
feat(tools/mini-engine): pocket stratified-Datalog engine in the WS s…

### DIFF
--- a/tools/mini-engine/README.md
+++ b/tools/mini-engine/README.md
@@ -1,0 +1,104 @@
+# mini-prologos — a pocket stratified-Datalog engine in the WS syntax
+
+A ~300-line, dependency-free JavaScript engine that parses the
+`defr` / `||` / `&>` / `solve` subset of Prologos WS-mode surface syntax and
+evaluates it bottom-up: monotone joins to a Tarski fixpoint per stratum,
+negation-as-failure only at stratum boundaries, with a round-by-round trace
+and a one-flag CALM order-independence check.
+
+**Provenance.** Built as the live in-browser engine for an interactive
+explainer of Prologos's lattice/CALM foundations (the "First, Choose Your
+Lattice" artifact, third in a series alongside Kuper's LVars dissertation,
+Radul's propagation networks, and the CALM theorem paper). Packaged here as a
+teaching and demo artifact — external contribution, not part of any Series
+track.
+
+**What it is NOT.** Not the Hyperlattice Compiler and not a Racket-pipeline
+citizen. No types, traits, schemas, modes-as-contracts, tabling machinery,
+`is`/functional goals, well-founded semantics, or the propagator substrate —
+when it meets cyclic negation it refuses with an error that points at
+`solver … :semantics well-founded`. It is a faithful miniature of the
+*evaluation story* (S0 monotone rounds → quiescence gate → S1 NAF), useful
+for demos, docs, and quick what-does-this-program-mean experiments.
+
+## Files
+
+| file | what |
+|---|---|
+| `mini-prologos.mjs` | the engine — pure ES module, no DOM, no deps |
+| `cli.mjs` | Node runner with `--trace` and `--shuffle N` (CALM check) |
+| `playground.html` | minimal browser playground (serve over HTTP) |
+| `test.mjs` | assertions over the demo programs (`node test.mjs`) |
+| `examples/prereqs.prologos` | transitive closure (relational-demo's course KB) |
+| `examples/routing.prologos` | stratified NAF (WFLE acceptance §A4's blocked/reachable) |
+
+## Quick start
+
+```sh
+cd tools/mini-engine
+node test.mjs
+node cli.mjs examples/prereqs.prologos 'solve (needs "CS401" req)' --trace --shuffle 20
+node cli.mjs examples/routing.prologos 'solve (reachable "a" dest)' --trace
+python3 -m http.server 8420   # then open http://localhost:8420/playground.html
+```
+
+Example output:
+
+```
+{:req "CS301"}
+{:req "CS201"}
+{:req "MA301"}
+{:req "CS101"}
+{:req "MA101"}
+
+;; --- trace ---
+;; S0 ground facts: prereq +5
+;; S0 round 1: needs +5
+;; S0 round 2: needs +3
+;; S0 round 3: needs +1
+;; quiescent — ...
+
+;; CALM check: 20 shuffled schedules, fire counts 6–8, fixpoint IDENTICAL every run ✓
+```
+
+## Supported subset
+
+```
+ns <name>                          accepted, ignored
+defr <name> [?a +b -c]             modes parsed, treated as documentation
+  || "v1" "v2" ...                 fact rows: quoted strings, grouped by arity
+  &> (goal) (goal) ...             rule clause; whitespace = conjunction,
+                                   repeated &> = disjunction
+goals    (rel a b) · (= a b) · (not (rel a b))
+args     "quoted" = constant · bare symbol = logic variable
+queries  solve (rel "const" var)   → list of binding maps
+```
+
+Semantics notes:
+
+- **Evaluation** is naive round-based bottom-up per stratum; the trace labels
+  rounds `S0 round 1 …` in the BSP spirit. Termination is structural: derived
+  tuples live in set-union cells over a finite constant universe.
+- **Stratification** is computed from negation edges; cyclic negation throws
+  `non-stratifiable`, by design mirroring the default engine's refusal (the
+  program wants the WFLE).
+- **`not` goals** need ground arguments at evaluation time; the evaluator
+  defers them behind positive goals within a clause where possible and throws
+  an informative error otherwise.
+- **CALM demos**: `evalProgram(rels, { shuffle })` takes any reordering
+  function for rule sets and tuple iteration; `dbSignature` makes fixpoint
+  equality checkable. `cli.mjs --shuffle N` packages the experiment.
+
+## API
+
+```js
+import { solve, parseProgram, parseQuery, evalProgram,
+         answers, dbSignature, shuffled } from './mini-prologos.mjs';
+
+const { answers } = solve(programSrc, 'solve (needs "CS401" req)');
+// → [{req: "CS301"}, …]
+
+const rels = parseProgram(programSrc);
+const res  = evalProgram(rels, { shuffle: shuffled });
+// res.DB (name → Map), res.trace (rounds & gates), res.S (strata), res.fires
+```

--- a/tools/mini-engine/cli.mjs
+++ b/tools/mini-engine/cli.mjs
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+/**
+ * mini-prologos CLI
+ *
+ *   node cli.mjs <file.prologos> 'solve (rel "c" x)' [--trace] [--shuffle N]
+ *
+ *   --trace      print the per-stratum BSP round log
+ *   --shuffle N  re-run N times with randomized firing orders and verify the
+ *                fixpoint is identical every time (the CALM check)
+ */
+import { readFileSync } from 'node:fs';
+import { parseProgram, parseQuery, evalProgram, answers, dbSignature, shuffled } from './mini-prologos.mjs';
+
+const args = process.argv.slice(2);
+const flags = { trace: false, shuffle: 0 };
+const pos = [];
+for (let i = 0; i < args.length; i++) {
+  if (args[i] === '--trace') flags.trace = true;
+  else if (args[i] === '--shuffle') flags.shuffle = +args[++i] || 20;
+  else pos.push(args[i]);
+}
+if (pos.length < 2) {
+  console.error('usage: node cli.mjs <file.prologos> \'solve (rel "c" x)\' [--trace] [--shuffle N]');
+  process.exit(2);
+}
+
+const src = readFileSync(pos[0], 'utf8');
+try {
+  const rels = parseProgram(src);
+  const q = parseQuery(pos[1], rels);
+  const res = evalProgram(rels, {});
+
+  const vars = q.args.filter(a => a.v !== undefined).map(a => a.v);
+  const ans = answers(q, res.DB);
+  if (!ans.length) console.log('nil');
+  else if (!vars.length) console.log(`true  ;; goal holds (${ans.length} matching tuple${ans.length > 1 ? 's' : ''})`);
+  else for (const e of ans) console.log('{' + vars.map(v => `:${v} ${JSON.stringify(e[v])}`).join(' ') + '}');
+
+  if (flags.trace) {
+    console.log('\n;; --- trace ---');
+    for (const ev of res.trace) {
+      if (ev.type === 'gate') { console.log(`;; ⟡ S${ev.stratum - 1} quiesced (Tarski fixpoint) — gate opens → S${ev.stratum}`); continue; }
+      const parts = Object.entries(ev.adds).map(([r, ts]) => `${r} +${ts.length}`);
+      console.log(`;; S${ev.stratum} ${ev.factsOnly ? 'ground facts' : 'round ' + ev.round}: ${parts.join(' · ') || '(no new tuples)'}`);
+    }
+    console.log(`;; quiescent — ${res.fires} rule-fires, ${Object.values(res.DB).reduce((n, m) => n + m.size, 0)} tuples, ${res.strata + 1} strat${res.strata ? 'a' : 'um'}`);
+  }
+
+  if (flags.shuffle) {
+    const sig0 = dbSignature(res.DB);
+    let minF = Infinity, maxF = 0, ok = true;
+    for (let t = 0; t < flags.shuffle; t++) {
+      const r = evalProgram(rels, { shuffle: shuffled });
+      minF = Math.min(minF, r.fires); maxF = Math.max(maxF, r.fires);
+      if (dbSignature(r.DB) !== sig0) ok = false;
+    }
+    console.log(`\n;; CALM check: ${flags.shuffle} shuffled schedules, fire counts ${minF}–${maxF}, fixpoint ${ok ? 'IDENTICAL every run ✓' : 'DIVERGED ✗ (engine bug!)'}`);
+    process.exit(ok ? 0 : 1);
+  }
+} catch (e) {
+  console.error('error: ' + e.message);
+  process.exit(1);
+}

--- a/tools/mini-engine/examples/prereqs.prologos
+++ b/tools/mini-engine/examples/prereqs.prologos
@@ -1,0 +1,16 @@
+;; Course-prerequisite knowledge base — the relational-demo tutorial's finale,
+;; sized for the mini engine. Try:
+;;   node ../cli.mjs prereqs.prologos 'solve (needs "CS401" req)' --trace --shuffle 20
+
+ns demo::prereqs
+
+defr prereq [?course ?requires]
+  || "CS201" "CS101"
+     "CS301" "CS201"
+     "CS301" "MA301"
+     "CS401" "CS301"
+     "MA301" "MA101"
+
+defr needs [?course ?req]
+  &> (prereq course req)
+  &> (prereq course mid) (needs mid req)

--- a/tools/mini-engine/examples/routing.prologos
+++ b/tools/mini-engine/examples/routing.prologos
@@ -1,0 +1,20 @@
+;; Stratified negation-as-failure — from the WFLE acceptance file §A4.
+;; edge/blocked live in stratum S0; reachable (which negates blocked) in S1.
+;; The S1 clauses only fire after S0 has reached its Tarski fixpoint.
+;;   node ../cli.mjs routing.prologos 'solve (reachable "a" dest)' --trace
+
+ns demo::routing
+
+defr edge [?from ?to]
+  || "a" "b"
+     "b" "c"
+     "c" "d"
+     "d" "e"
+
+defr blocked [?node]
+  || "c"
+
+defr reachable [?from ?to]
+  &> (edge from to) (not (blocked to))
+  &> (edge from mid) (not (blocked mid))
+     (reachable mid to)

--- a/tools/mini-engine/mini-prologos.mjs
+++ b/tools/mini-engine/mini-prologos.mjs
@@ -1,0 +1,332 @@
+/**
+ * mini-prologos — a tiny stratified bottom-up Datalog engine that speaks a
+ * subset of Prologos WS-mode surface syntax.
+ *
+ * Origin: built as the live in-browser engine for the interactive explainer
+ * "First, Choose Your Lattice — Prologos, Interactive" (an architect-oriented
+ * tour of the lattice/CALM foundations). Packaged here as a self-contained
+ * teaching/demo artifact. It is a faithful *miniature* of the evaluation
+ * story — monotone joins to a Tarski fixpoint per stratum, negation only at
+ * stratum boundaries — NOT the Hyperlattice Compiler, and it deliberately
+ * knows nothing about types, traits, tabling internals, or the propagator
+ * substrate.
+ *
+ * Supported subset:
+ *   ns <name>                        -- accepted and ignored
+ *   defr <name> [?a +b -c]          -- relation declaration (modes ignored)
+ *     || "v" "v" ...                 -- fact rows (quoted strings, arity-grouped)
+ *     &> (goal) (goal) ...           -- rule clause; goals conjoined
+ *   goals: (rel a b) | (= a b) | (not (rel a b))
+ *   args : "quoted"  = constant · bare-symbol = variable
+ *   query: solve (rel "c" x)   — via parseQuery
+ *
+ * Semantics:
+ *   - Naive/round-based bottom-up evaluation per stratum (rounds are the
+ *     BSP-flavored trace), derived tuples accumulate in set-union cells.
+ *   - Stratification by negation; cyclic negation is refused with an error
+ *     (that program wants the well-founded solver, which this mini is not).
+ *   - `not` goals require ground arguments at evaluation time; they are
+ *     deferred behind positive goals within a clause where possible.
+ *   - evalProgram(rels, {shuffle}) accepts a reordering function so callers
+ *     can demonstrate the CALM property: any firing order, same fixpoint.
+ */
+
+/* ---------------- tokenizer ---------------- */
+
+export function tokenize(src) {
+  const toks = [];
+  src = src.replace(/;;[^\n]*/g, '');
+  const re = /"([^"]*)"|\|\||&>|[()\[\]]|[^\s()\[\]"]+/g;
+  let m;
+  while ((m = re.exec(src))) {
+    if (m[1] !== undefined) toks.push({ t: 'str', v: m[1] });
+    else toks.push({ t: 'sym', v: m[0] });
+  }
+  return toks;
+}
+
+/* ---------------- parser ---------------- */
+
+export function parseProgram(src) {
+  const toks = tokenize(src);
+  let i = 0;
+  const peek = () => toks[i], next = () => toks[i++];
+  const rels = {};   // name -> {arity, facts:[[c,...]], rules:[{head:[args], goals:[...]}]}
+  function need(cond, msg) { if (!cond) throw new Error(msg); }
+  function ensureRel(name, arity) {
+    if (!rels[name]) rels[name] = { arity, facts: [], rules: [] };
+    else need(rels[name].arity === arity, `arity mismatch for ${name}: ${rels[name].arity} vs ${arity}`);
+    return rels[name];
+  }
+  function parseGoal() { // at '('
+    need(peek() && peek().v === '(', 'expected ( to open a goal');
+    next();
+    const head = next();
+    need(head, 'unterminated goal');
+    if (head.v === 'not') {
+      const inner = parseGoal();
+      need(peek() && peek().v === ')', 'expected ) after not-goal');
+      next();
+      need(inner.kind === 'call', 'not(...) must wrap a relation goal');
+      return { kind: 'not', goal: inner };
+    }
+    if (head.v === '=') {
+      const a = parseArg(), b = parseArg();
+      need(peek() && peek().v === ')', 'expected ) after (= a b)');
+      next();
+      return { kind: 'unify', a, b };
+    }
+    need(head.t === 'sym', 'goal must start with a relation name');
+    const args = [];
+    while (peek() && peek().v !== ')') args.push(parseArg());
+    need(peek(), 'unterminated goal ' + head.v);
+    next(); // )
+    return { kind: 'call', rel: head.v, args };
+  }
+  function parseArg() {
+    const tk = next();
+    need(tk, 'unexpected end of input in goal');
+    if (tk.t === 'str') return { c: tk.v };
+    need(!'()[]'.includes(tk.v), 'unexpected ' + tk.v + ' in goal arguments');
+    return { v: tk.v };
+  }
+  while (i < toks.length) {
+    const tk = next();
+    if (tk.v === 'ns') { next(); continue; }
+    if (tk.v === 'solve') { // top-level solve in a program file: parse & ignore
+      if (peek() && peek().v === '(') parseGoal();
+      continue;
+    }
+    if (tk.v === 'defr') {
+      const nameTok = next();
+      need(nameTok && nameTok.t === 'sym', 'defr needs a name');
+      const name = nameTok.v;
+      need(peek() && peek().v === '[', `defr ${name}: expected [params]`);
+      next();
+      const params = [];
+      while (peek() && peek().v !== ']') {
+        const p = next();
+        need(p.t === 'sym', `defr ${name}: bad param`);
+        params.push(p.v);
+      }
+      need(peek(), `defr ${name}: unterminated [params]`);
+      next(); // ]
+      const rel = ensureRel(name, params.length);
+      while (peek() && (peek().v === '||' || peek().v === '&>')) {
+        const sig = next().v;
+        if (sig === '||') {
+          while (peek() && peek().t === 'str') {
+            const row = [];
+            for (let k = 0; k < params.length; k++) {
+              const c = next();
+              need(c && c.t === 'str', `fact row for ${name}: expected ${params.length} quoted values per row`);
+              row.push(c.v);
+            }
+            rel.facts.push(row);
+          }
+        } else { // &>
+          const goals = [];
+          while (peek() && peek().v === '(') goals.push(parseGoal());
+          need(goals.length > 0, `&> clause of ${name} has no goals`);
+          rel.rules.push({ head: params.map(p => ({ v: p.replace(/^[?+\-]/, '') })), goals });
+        }
+      }
+      continue;
+    }
+    throw new Error(`unexpected token “${tk.v}” at top level (this engine speaks the defr/||/&>/solve subset)`);
+  }
+  // reference check
+  for (const [name, rel] of Object.entries(rels))
+    for (const rule of rel.rules)
+      for (const g of rule.goals) {
+        const call = g.kind === 'not' ? g.goal : g;
+        if (call.kind === 'call') {
+          if (!rels[call.rel]) throw new Error(`unknown relation (${call.rel} …) in a clause of ${name}`);
+          if (rels[call.rel].arity !== call.args.length)
+            throw new Error(`(${call.rel} …) called with ${call.args.length} args; declared arity ${rels[call.rel].arity}`);
+        }
+      }
+  return rels;
+}
+
+export function parseQuery(src, rels) {
+  const m = src.match(/solve\s*(\(.*\))\s*$/s) || src.match(/^\s*(\(.*\))\s*$/s);
+  if (!m) throw new Error('query should look like: solve (needs "CS401" req)');
+  const toks = tokenize(m[1]);
+  let i = 0;
+  if (toks[i].v !== '(') throw new Error('query: expected (goal …)');
+  i++;
+  const name = toks[i++].v;
+  if (!rels[name]) throw new Error(`query: unknown relation ${name}`);
+  const args = [];
+  while (i < toks.length && toks[i].v !== ')') {
+    const tk = toks[i++];
+    args.push(tk.t === 'str' ? { c: tk.v } : { v: tk.v });
+  }
+  if (rels[name].arity !== args.length) throw new Error(`query: ${name} has arity ${rels[name].arity}`);
+  return { rel: name, args };
+}
+
+/* ---------------- stratification ---------------- */
+
+export function stratify(rels) {
+  const names = Object.keys(rels);
+  const S = {};
+  names.forEach(n => S[n] = 0);
+  const maxS = names.length + 1;
+  for (let pass = 0; pass <= maxS + 1; pass++) {
+    let changed = false;
+    for (const [h, rel] of Object.entries(rels))
+      for (const rule of rel.rules)
+        for (const g of rule.goals) {
+          if (g.kind === 'call' && S[h] < S[g.rel]) { S[h] = S[g.rel]; changed = true; }
+          if (g.kind === 'not' && S[h] < S[g.goal.rel] + 1) { S[h] = S[g.goal.rel] + 1; changed = true; }
+        }
+    if (!changed) break;
+    if (pass === maxS + 1 || Math.max(...Object.values(S)) > maxS)
+      throw new Error('non-stratifiable: cyclic negation — the stratified engine refuses this program. It wants a well-founded solver (solver … :semantics well-founded).');
+  }
+  return S;
+}
+
+/* ---------------- evaluation ---------------- */
+
+export const keyOf = t => JSON.stringify(t);
+
+function unifyGoal(goal, tuple, env) {
+  const e = { ...env };
+  for (let k = 0; k < goal.args.length; k++) {
+    const a = goal.args[k];
+    if (a.c !== undefined) { if (tuple[k] !== a.c) return null; }
+    else {
+      if (e[a.v] !== undefined) { if (e[a.v] !== tuple[k]) return null; }
+      else e[a.v] = tuple[k];
+    }
+  }
+  return e;
+}
+const argVal = (a, env) => a.c !== undefined ? a.c : env[a.v];
+
+/**
+ * Evaluate a parsed program to its stratified fixpoint.
+ * opts.shuffle: optional (array => array) reordering applied to rule sets and
+ *               tuple iteration each round — for CALM order-independence demos.
+ * Returns {DB, trace, S, fires, strata}:
+ *   DB     : name -> Map(key -> tuple)
+ *   trace  : [{type:'gate',stratum} | {type:'round',stratum,round,adds,factsOnly?}]
+ *   S      : name -> stratum index
+ *   fires  : total rule-fire count (varies with order; the fixpoint does not)
+ */
+export function evalProgram(rels, opts = {}) {
+  const S = stratify(rels);
+  const strata = Object.keys(rels).length ? Math.max(...Object.values(S)) : 0;
+  const DB = {};
+  const trace = [];
+  let fires = 0;
+  for (const [n, rel] of Object.entries(rels)) {
+    DB[n] = new Map();
+    rel.facts.forEach(f => DB[n].set(keyOf(f), f));
+  }
+  const ord = opts.shuffle || (a => a);
+  function solveGoals(goals, env, out) {
+    if (!goals.length) { out.push(env); return; }
+    const [g, ...rest] = goals;
+    if (g.kind === 'unify') {
+      const av = argVal(g.a, env), bv = argVal(g.b, env);
+      if (av !== undefined && bv !== undefined) { if (av === bv) solveGoals(rest, env, out); }
+      else if (av !== undefined && g.b.v) solveGoals(rest, { ...env, [g.b.v]: av }, out);
+      else if (bv !== undefined && g.a.v) solveGoals(rest, { ...env, [g.a.v]: bv }, out);
+      else throw new Error('(= a b): both sides unbound');
+      return;
+    }
+    if (g.kind === 'not') {
+      const call = g.goal;
+      if (call.args.some(a => a.v !== undefined && env[a.v] === undefined)) {
+        // defer behind remaining positive goals if any exist
+        if (rest.some(r => r.kind !== 'not')) { solveGoals([...rest, g], env, out); return; }
+        throw new Error(`(not (${call.rel} …)) reached with unbound variables — ground them with a positive goal first`);
+      }
+      const tuple = call.args.map(a => argVal(a, env));
+      if (!DB[call.rel].has(keyOf(tuple))) solveGoals(rest, env, out);
+      return;
+    }
+    for (const tuple of ord([...DB[g.rel].values()])) {
+      const e2 = unifyGoal(g, tuple, env);
+      if (e2) solveGoals(rest, e2, out);
+    }
+  }
+  for (let s = 0; s <= strata; s++) {
+    if (s > 0) trace.push({ type: 'gate', stratum: s });
+    const factAdds = {};
+    for (const [n, rel] of Object.entries(rels))
+      if (S[n] === s && rel.facts.length) factAdds[n] = rel.facts;
+    if (Object.keys(factAdds).length)
+      trace.push({ type: 'round', stratum: s, round: 0, adds: factAdds, factsOnly: true });
+    const ruleset = [];
+    for (const [h, rel] of Object.entries(rels))
+      if (S[h] === s) rel.rules.forEach(r => ruleset.push({ head: h, rule: r }));
+    let round = 0;
+    while (true) {
+      round++;
+      const adds = {};
+      let any = false;
+      for (const { head, rule } of ord(ruleset.slice())) {
+        fires++;
+        const envs = [];
+        solveGoals(rule.goals, {}, envs);
+        for (const env of envs) {
+          const tuple = rule.head.map(a => {
+            const v = argVal(a, env);
+            if (v === undefined) throw new Error(`unbound variable ${a.v} in the head of a ${head} clause`);
+            return v;
+          });
+          const k = keyOf(tuple);
+          if (!DB[head].has(k)) {
+            DB[head].set(k, tuple);
+            (adds[head] = adds[head] || []).push(tuple);
+            any = true;
+          }
+        }
+      }
+      if (ruleset.length && (any || round === 1)) trace.push({ type: 'round', stratum: s, round, adds });
+      if (!any) break;
+      if (round > 500) throw new Error('runaway (500 rounds) — is the fact universe infinite?');
+    }
+  }
+  return { DB, trace, S, fires, strata };
+}
+
+/** Match a parsed query against the fixpoint DB → array of binding envs. */
+export function answers(q, DB) {
+  const out = [];
+  for (const tuple of DB[q.rel].values()) {
+    const e = unifyGoal(q, tuple, {});
+    if (e) out.push(e);
+  }
+  return out;
+}
+
+/** Canonical signature of a DB — equal iff the fixpoints are equal. */
+export function dbSignature(DB) {
+  return Object.entries(DB)
+    .map(([n, m]) => n + ':' + [...m.keys()].sort().join('|'))
+    .sort().join('§');
+}
+
+/** Fisher–Yates, non-mutating — a ready-made opts.shuffle for CALM demos. */
+export function shuffled(a) {
+  a = a.slice();
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [a[i], a[j]] = [a[j], a[i]];
+  }
+  return a;
+}
+
+/** Convenience: parse + eval + query in one call. */
+export function solve(programSrc, querySrc, opts = {}) {
+  const rels = parseProgram(programSrc);
+  const q = parseQuery(querySrc, rels);
+  const res = evalProgram(rels, opts);
+  return { answers: answers(q, res.DB), ...res, query: q };
+}

--- a/tools/mini-engine/playground.html
+++ b/tools/mini-engine/playground.html
@@ -1,0 +1,122 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>mini-prologos playground</title>
+<style>
+  :root{--bg:#f5f3f8;--card:#fcfbfe;--well:#ece9f2;--ink:#231f2e;--muted:#645e74;
+    --line:#dcd7e6;--accent:#5d34d8;--gold:#9a7514;--good:#177a50;--bad:#c22b45}
+  @media (prefers-color-scheme:dark){
+    :root{--bg:#131019;--card:#1c1826;--well:#161320;--ink:#e9e6f0;--muted:#a49db8;
+      --line:#2e2940;--accent:#a98bff;--gold:#e0bc5d;--good:#48c792;--bad:#ff7089}}
+  body{margin:0;background:var(--bg);color:var(--ink);
+    font:15px/1.6 system-ui,sans-serif;padding:2rem 1.2rem}
+  main{max-width:64rem;margin:0 auto}
+  h1{font-size:1.3rem;margin:0 0 .3rem}
+  p.sub{color:var(--muted);margin:0 0 1.4rem;font-size:.9rem}
+  .grid{display:grid;grid-template-columns:1.1fr 1fr;gap:1.2rem}
+  @media (max-width:800px){.grid{grid-template-columns:1fr}}
+  label{display:block;font:600 .68rem/1 ui-monospace,monospace;letter-spacing:.12em;
+    text-transform:uppercase;color:var(--muted);margin:0 0 .4rem}
+  textarea,input[type=text]{width:100%;box-sizing:border-box;font:13px/1.6 ui-monospace,monospace;
+    color:var(--ink);background:var(--well);border:1.5px solid var(--line);border-radius:8px;
+    padding:.7rem .9rem}
+  textarea{min-height:17rem;resize:vertical;white-space:pre;tab-size:2}
+  textarea:focus,input:focus{outline:none;border-color:var(--accent)}
+  .row{display:flex;gap:.6rem;margin:.8rem 0 0;flex-wrap:wrap}
+  button{font:600 .78rem ui-monospace,monospace;border-radius:7px;padding:.55rem .95rem;
+    cursor:pointer;border:1.5px solid var(--accent);background:var(--accent);color:var(--bg)}
+  button.ghost{background:transparent;color:var(--accent)}
+  .out{background:var(--card);border:1px solid var(--line);border-radius:8px;padding:.7rem 1rem;
+    font:13px/1.9 ui-monospace,monospace;min-height:3rem;overflow:auto;margin-bottom:.9rem}
+  .trace{background:var(--well);border:1px solid var(--line);border-radius:8px;padding:.7rem 1rem;
+    font:12px/1.85 ui-monospace,monospace;color:var(--muted);max-height:18rem;overflow:auto}
+  .trace .gate{color:var(--gold);display:block;border-top:1.5px dashed var(--gold);
+    margin:.35rem 0 .25rem;padding-top:.25rem}
+  .ans{color:var(--accent)} .err{color:var(--bad)} .okv{color:var(--good)} .nil{color:var(--muted);font-style:italic}
+</style>
+</head>
+<body>
+<main>
+  <h1>mini-prologos playground</h1>
+  <p class="sub">A stratified bottom-up Datalog engine over the <code>defr</code> / <code>||</code> / <code>&amp;&gt;</code> / <code>solve</code>
+    subset of Prologos WS syntax. Serve this directory (<code>python3 -m http.server</code>) — ES-module
+    imports don’t load from <code>file://</code>.</p>
+  <div class="grid">
+    <div>
+      <label for="src">program</label>
+      <textarea id="src" spellcheck="false">ns demo::prereqs
+
+defr prereq [?course ?requires]
+  || "CS201" "CS101"
+     "CS301" "CS201"
+     "CS301" "MA301"
+     "CS401" "CS301"
+     "MA301" "MA101"
+
+defr needs [?course ?req]
+  &> (prereq course req)
+  &> (prereq course mid) (needs mid req)</textarea>
+      <label for="qy" style="margin-top:.8rem">query</label>
+      <input type="text" id="qy" value='solve (needs "CS401" req)' spellcheck="false">
+      <div class="row">
+        <button id="run">solve</button>
+        <button id="shuffle" class="ghost">CALM check ×20</button>
+      </div>
+    </div>
+    <div>
+      <label>answers</label>
+      <div class="out" id="ans"><span class="nil">— run the query —</span></div>
+      <label>trace (strata &amp; BSP rounds)</label>
+      <div class="trace" id="trace">Rounds of monotone joins; quiescence = Tarski fixpoint;
+negation only after the gate.</div>
+    </div>
+  </div>
+</main>
+<script type="module">
+import { parseProgram, parseQuery, evalProgram, answers, dbSignature, shuffled }
+  from './mini-prologos.mjs';
+const $ = id => document.getElementById(id);
+const esc = s => String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+function run() {
+  try {
+    const rels = parseProgram($('src').value);
+    const q = parseQuery($('qy').value, rels);
+    const res = evalProgram(rels);
+    const vars = q.args.filter(a => a.v !== undefined).map(a => a.v);
+    const ans = answers(q, res.DB);
+    $('ans').innerHTML = !ans.length ? '<span class="nil">nil — no answers</span>'
+      : !vars.length ? `<span class="ans">true</span> (${ans.length} match${ans.length>1?'es':''})`
+      : ans.map(e => '<span class="ans">{' + vars.map(v => ':'+v+' "'+esc(e[v])+'"').join(' ') + '}</span>').join('<br>');
+    const lines = [];
+    for (const ev of res.trace) {
+      if (ev.type === 'gate') { lines.push(`<span class="gate">⟡ S${ev.stratum-1} quiesced — gate opens → S${ev.stratum}</span>`); continue; }
+      const parts = Object.entries(ev.adds).map(([r, ts]) => `${r} +${ts.length}`);
+      lines.push(`S${ev.stratum} ${ev.factsOnly ? 'ground facts' : 'round ' + ev.round} — ${parts.join(' · ') || 'no new tuples'}`);
+    }
+    lines.push(`<b>quiescent · ${res.fires} fires · ${Object.values(res.DB).reduce((n,m)=>n+m.size,0)} tuples</b>`);
+    $('trace').innerHTML = lines.join('<br>');
+    return rels;
+  } catch (e) {
+    $('ans').innerHTML = '<span class="err">' + esc(e.message) + '</span>';
+    $('trace').textContent = '—';
+    return null;
+  }
+}
+$('run').addEventListener('click', run);
+$('shuffle').addEventListener('click', () => {
+  const rels = run(); if (!rels) return;
+  const sig0 = dbSignature(evalProgram(rels).DB);
+  let ok = true, min = Infinity, max = 0;
+  for (let t = 0; t < 20; t++) {
+    const r = evalProgram(rels, { shuffle: shuffled });
+    min = Math.min(min, r.fires); max = Math.max(max, r.fires);
+    if (dbSignature(r.DB) !== sig0) ok = false;
+  }
+  $('trace').innerHTML += `<br><span class="${ok?'okv':'err'}">CALM ×20: fire counts ${min}–${max}, fixpoint ${ok?'identical every run ✓':'DIVERGED ✗'}</span>`;
+});
+run();
+</script>
+</body>
+</html>

--- a/tools/mini-engine/test.mjs
+++ b/tools/mini-engine/test.mjs
@@ -1,0 +1,101 @@
+/** Tests for mini-prologos. Run: node test.mjs */
+import assert from 'node:assert/strict';
+import { parseProgram, parseQuery, evalProgram, answers, dbSignature, shuffled, solve } from './mini-prologos.mjs';
+
+let n = 0;
+const test = (name, fn) => { fn(); n++; console.log('ok - ' + name); };
+
+const PREREQS = `
+ns demo::prereqs
+defr prereq [?course ?requires]
+  || "CS201" "CS101"
+     "CS301" "CS201"
+     "CS301" "MA301"
+     "CS401" "CS301"
+     "MA301" "MA101"
+defr needs [?course ?req]
+  &> (prereq course req)
+  &> (prereq course mid) (needs mid req)
+`;
+
+const ROUTING = `
+defr edge [?from ?to]
+  || "a" "b"
+     "b" "c"
+     "c" "d"
+     "d" "e"
+defr blocked [?node]
+  || "c"
+defr reachable [?from ?to]
+  &> (edge from to) (not (blocked to))
+  &> (edge from mid) (not (blocked mid)) (reachable mid to)
+`;
+
+test('transitive closure: all prerequisites of CS401', () => {
+  const { answers: ans } = solve(PREREQS, 'solve (needs "CS401" req)');
+  const got = ans.map(e => e.req).sort();
+  assert.deepEqual(got, ['CS101', 'CS201', 'CS301', 'MA101', 'MA301']);
+});
+
+test('ground query returns truth, not bindings', () => {
+  const { answers: ans } = solve(PREREQS, 'solve (needs "CS401" "MA101")');
+  assert.equal(ans.length, 1);
+});
+
+test('no-answer query yields nil (empty)', () => {
+  const { answers: ans } = solve(PREREQS, 'solve (needs "CS101" req)');
+  assert.equal(ans.length, 0);
+});
+
+test('stratified negation: blocked node cuts reachability', () => {
+  const { answers: ans, strata } = solve(ROUTING, 'solve (reachable "a" dest)');
+  assert.deepEqual(ans.map(e => e.dest).sort(), ['b']);
+  assert.equal(strata, 1); // edge/blocked in S0, reachable in S1
+});
+
+test('removing the blocked fact restores the path', () => {
+  const src = ROUTING.replace('|| "c"', '|| "zzz"');
+  const { answers: ans } = solve(src, 'solve (reachable "a" dest)');
+  assert.deepEqual(ans.map(e => e.dest).sort(), ['b', 'c', 'd', 'e']);
+});
+
+test('gate appears in the trace before the negation stratum', () => {
+  const rels = parseProgram(ROUTING);
+  const { trace } = evalProgram(rels);
+  const gate = trace.findIndex(ev => ev.type === 'gate');
+  assert.ok(gate > 0, 'expected an S0→S1 gate event');
+  assert.ok(trace.slice(0, gate).every(ev => ev.stratum === 0));
+});
+
+test('cyclic negation is refused (points at well-founded semantics)', () => {
+  const src = ROUTING + '\ndefr win [?x]\n  &> (edge x y) (not (win y))\n';
+  assert.throws(() => solve(src, 'solve (win x)'), /non-stratifiable/);
+});
+
+test('CALM: 25 shuffled schedules reach the identical fixpoint', () => {
+  const rels = parseProgram(PREREQS);
+  const sig0 = dbSignature(evalProgram(rels).DB);
+  const fireCounts = new Set();
+  for (let t = 0; t < 25; t++) {
+    const r = evalProgram(rels, { shuffle: shuffled });
+    fireCounts.add(r.fires);
+    assert.equal(dbSignature(r.DB), sig0, 'fixpoint diverged under shuffle');
+  }
+  // not asserted (schedules *may* coincide), but typically >1 distinct count:
+  console.log(`  # fire-count spread across schedules: {${[...fireCounts].sort((a, b) => a - b).join(', ')}}`);
+});
+
+test('unification goal (= x y) binds and filters', () => {
+  const src = 'defr pairish [?x ?y]\n  || "a" "a"\n     "a" "b"\ndefr same [?x]\n  &> (pairish x y) (= x y)\n';
+  const { answers: ans } = solve(src, 'solve (same v)');
+  assert.deepEqual(ans.map(e => e.v), ['a']);
+});
+
+test('parse errors are informative', () => {
+  assert.throws(() => parseProgram('defr broken [?x ?y]\n  || "a"'), /expected 2 quoted values per row/);
+  assert.throws(() => parseProgram('defr r [?x]\n  &> (nosuch x)'), /unknown relation/);
+  const rels = parseProgram('defr r [?x]\n  || "a"');
+  assert.throws(() => parseQuery('solve (r "a" "b")', rels), /arity/);
+});
+
+console.log(`\n${n} tests passed`);


### PR DESCRIPTION
…yntax

A dependency-free JS miniature of the evaluation story — defr/||/&>/solve parsed from WS-mode surface syntax, naive bottom-up rounds to a Tarski fixpoint per stratum, NAF only behind the S0 quiescence gate, cyclic negation refused with a pointer at the well-founded solver. Ships a Node CLI (--trace, --shuffle N CALM check), a browser playground, tests (10 passing), and example programs drawn from relational-demo and the WFLE acceptance file.

Origin: built as the live engine for the interactive lattice/CALM explainer of Prologos; packaged as a self-contained teaching artifact under tools/. External contribution — not part of any Series track; no Racket-pipeline coupling.